### PR TITLE
npm: update repo links to reflect move to pouchdb org

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/daleharvey/pouchdb-express-router.git"
+    "url": "https://github.com/pouchdb/pouchdb-express-router.git"
   },
   "keywords": [
     "pouchdb",
@@ -28,7 +28,7 @@
   "author": "Dale Harvey",
   "license": "Apache v2",
   "bugs": {
-    "url": "https://github.com/daleharvey/pouchdb-express-router/issues"
+    "url": "https://github.com/pouchdb/pouchdb-express-router/issues"
   },
-  "homepage": "https://github.com/daleharvey/pouchdb-express-router"
+  "homepage": "https://github.com/pouchdb/pouchdb-express-router"
 }


### PR DESCRIPTION
Per move from daleharvey to pouchdb: https://github.com/pouchdb/pouchdb/pull/4050#issuecomment-122787424